### PR TITLE
Update joi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/petey/retry-function",
   "dependencies": {
-    "joi": "^6.0.7",
+    "joi": "^9.1.1",
     "retry": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`Joi.reach` is not available in version 6: https://github.com/hapijs/joi/blob/44e8bb4c12a33697c6dfde756326d02eb40c0299/API.md

This is pulled in by circuit-fuses. 

This might be the cause for https://github.com/screwdriver-cd/screwdriver/issues/274
